### PR TITLE
host: ignore errors when setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ base_hosts: false
 base_hosts_suffix: ""
 base_manage_host_file: true
 base_custom_hosts: {}
+base_ignore_hostname_setup_error: false
 
 base_manage_host_r53: false
 base_r53_internal_zone: ""

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -12,6 +12,7 @@
 - name: "Setup hostname"
   hostname: name="{{ec2_tag_Name}}"
   when: ec2_tag_Name is defined
+  ignore_errors: "{{ base_ignore_hostname_setup_error }}"
 
 - name: "Set facts with hostname"
   set_fact: ansible_hostname="{{ec2_tag_Name}}"


### PR DESCRIPTION
Is it sometimes useful (e.g. in Ubuntu) to ignore errors when setuping
the hostname because this fail randomly, and can require to upgrade
kernels.

As the playbook are played frequently enough through a setup, ignoring
such error - which doesn't include anything critical - seems fine.