### PR TITLE
apt: adding ignore error on update to avoid fail when apt keyu changed during ASG startup

### DIFF
--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -1,6 +1,11 @@
 ---
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=86400
+  ignore_errors: yes
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
 - name: Debian | Install list of packages
-  apt: pkg={{item}} state=installed update_cache=yes
+  apt: pkg={{item}} state=installed
   with_items:
     - rsync
     - tar
@@ -25,7 +30,7 @@
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Debian 8 | Install list of packages
-  apt: pkg={{item}} state=installed update_cache=yes
+  apt: pkg={{item}} state=installed
   with_items:
     - dbus
   when: ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie'
@@ -73,7 +78,7 @@
 - user: name=admin group=admin shell=/bin/bash state=present skeleton=/etc/skel
 
 - name: Debian | Install extra list of packages
-  apt: pkg={{item}} state=installed update_cache=yes
+  apt: pkg={{item}} state=installed
   with_items:
     - "{{ base_extra_packages }}"
   when: base_extra_packages|length > 0 and (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')


### PR DESCRIPTION
apt: adding ignore error on update to avoid fail when apt keyu changed during ASG startup