### PR TITLE
hosname: remove unwanted chars

### DIFF
--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -10,7 +10,7 @@
   when: base_global_hosts is defined
 
 - name: "Setup hostname"
-  hostname: name="{{ec2_tag_Name}}"
+  hostname: name="{{ec2_tag_Name | regex_replace("[^A-Za-z0-9-]", "-")}}"
   when: ec2_tag_Name is defined
   ignore_errors: "{{ base_ignore_hostname_setup_error }}"
 


### PR DESCRIPTION
Aws Name tag is more flexible that server hostname. Make sure to remove unsupported chars